### PR TITLE
Add Krakow Airport arrivals scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,26 @@
+name: scrape
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run scrape
+      - name: Commit CSV
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/arrivals.csv
+          if ! git diff --cached --quiet; then
+            git commit -m "update arrivals [skip ci]"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# codex-test
+
+## Usage
+
+- `npm run start` – prints a test message.
+- `npm run scrape` – downloads the latest arrivals into `data/arrivals.csv`.
+
+### Google Sheets
+
+If this repository is public, import the CSV into Google Sheets:
+
+```
+=IMPORTDATA("https://raw.githubusercontent.com/<user>/<repo>/main/data/arrivals.csv")
+```
+
+If the repository is private, `IMPORTDATA` will not work; make the repo public or host the CSV on GitHub Pages.

--- a/data/arrivals.csv
+++ b/data/arrivals.csv
@@ -1,0 +1,1 @@
+planned_time;flight_number;from;status;airline

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+console.log("Codex is working 🚀");
+console.log(2 + 2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "codex-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.54.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "codex-test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node index.js",
+    "scrape": "node scrape.js"
+  },
+  "dependencies": {
+    "playwright": "^1.54.2"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,0 @@
-# codex-test
-Initial commit

--- a/scrape.js
+++ b/scrape.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const url = 'https://krakowairport.pl/pl/pasazer/loty/przyloty';
+const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ userAgent });
+  const page = await context.newPage();
+  const xhrUrls = [];
+  page.on('request', req => {
+    const type = req.resourceType();
+    if (type === 'xhr' || type === 'fetch') {
+      xhrUrls.push(req.url());
+    }
+  });
+
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('table tbody tr', { timeout: 15000 });
+    const rows = await page.$$eval('table tbody tr', trs =>
+      trs.map(tr => {
+        const tds = Array.from(tr.querySelectorAll('td')).map(td => td.textContent.trim());
+        return {
+          time: tds[0] || '',
+          flight: tds[1] || '',
+          from: tds[2] || '',
+          status: tds[3] || '',
+          airline: tds[4] || '',
+        };
+      })
+    );
+    saveCsv(rows);
+  } catch (err) {
+    console.error('HTML parsing failed:', err.message);
+    if (xhrUrls.length) {
+      console.log('Captured XHR/fetch URLs:');
+      xhrUrls.forEach(u => console.log(u));
+      for (const u of xhrUrls) {
+        try {
+          const resp = await fetch(u);
+          if (!resp.ok) continue;
+          const json = await resp.json();
+          const items = Array.isArray(json) ? json : json.data || json.items || [];
+          if (Array.isArray(items) && items.length) {
+            const rows = items.map(item => ({
+              time: item.time || item.planned || item.eta || item.sta || item.schedule || '',
+              flight: item.flight || item.flightNo || item.number || '',
+              from: item.from || item.origin || item.direction || '',
+              status: item.status || '',
+              airline: item.airline || item.carrier || '',
+            }));
+            saveCsv(rows);
+            break;
+          }
+        } catch (_) {
+          // ignore fetch errors
+        }
+      }
+    }
+    if (!fs.existsSync(path.join(__dirname, 'data', 'arrivals.csv'))) {
+      saveCsv([]);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  function saveCsv(rows) {
+    const headers = ['planned_time', 'flight_number', 'from', 'status', 'airline'];
+    const csvLines = [headers.join(';'), ...rows.map(r => `${r.time};${r.flight};${r.from};${r.status};${r.airline}`)];
+    fs.mkdirSync(path.join(__dirname, 'data'), { recursive: true });
+    fs.writeFileSync(path.join(__dirname, 'data', 'arrivals.csv'), csvLines.join('\n') + '\n', 'utf8');
+    console.log(csvLines.slice(0, 6).join('\n'));
+  }
+})();


### PR DESCRIPTION
## Summary
- add Playwright-based `scrape.js` to pull Krakow Airport arrivals into a semicolon-delimited CSV
- schedule scraping workflow on a 10-minute cron that commits updated CSVs
- document usage and Google Sheets import in README

## Testing
- `npm run scrape` *(fails to reach krakowairport.pl: net::ERR_TUNNEL_CONNECTION_FAILED but writes header to data/arrivals.csv)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a156784832c8fc7151403bf0c86